### PR TITLE
Update VMs.json

### DIFF
--- a/Allfiles/Exercises/M07/VMs.json
+++ b/Allfiles/Exercises/M07/VMs.json
@@ -264,7 +264,7 @@
   "name":  "[variables('PIPName1')]",
   "location": "[resourceGroup().location]",
   "sku": {
-    "name": "Basic",
+    "name": "Standard",
     "tier": "Regional"
   },
   "properties": {


### PR DESCRIPTION
Change SKU from Basic to Standard. Basic is being deprecated and withdrawn from service

Basic SKU was not available in the region I use, South Africa North, and I had to use Standard SKU

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

- change SKU from 'Basic' to 'Standard'
-
-

### Relevant Issues link

